### PR TITLE
Fix 1.21.11 crash + track manual /home teleports, transparency & keybind toggle

### DIFF
--- a/src/main/java/com/maxlananas/homegui/HomeGuiClient.java
+++ b/src/main/java/com/maxlananas/homegui/HomeGuiClient.java
@@ -57,4 +57,9 @@ public class HomeGuiClient implements ClientModInitializer {
         pendingCoordHome = homeName;
         coordCaptureCountdown = 20;
     }
+
+    /** True if the given key event matches the (possibly rebound) "open GUI" keybind. */
+    public static boolean matchesOpenKey(net.minecraft.client.input.KeyEvent event) {
+        return openGuiKey != null && openGuiKey.matches(event);
+    }
 }

--- a/src/main/java/com/maxlananas/homegui/HomesManager.java
+++ b/src/main/java/com/maxlananas/homegui/HomesManager.java
@@ -1,5 +1,6 @@
 package com.maxlananas.homegui;
 
+import com.maxlananas.homegui.config.ModConfig;
 import net.minecraft.client.Minecraft;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -18,6 +19,10 @@ public class HomesManager {
     private boolean waiting = false;
     private long requestTime = 0;
     private static final long TIMEOUT = 5000L;
+
+    // Matches a "home <name>" teleport command (with or without a leading slash),
+    // but not the "homes" list command (which has no argument).
+    private static final Pattern HOME_CMD = Pattern.compile("(?i)^/?home\\s+(\\S+)");
 
     private static final Pattern BRACKET = Pattern.compile("\\[([^\\]]+)\\]");
     private static final Pattern[] NAMED = {
@@ -49,6 +54,27 @@ public class HomesManager {
             mc.player.connection.sendCommand("home " + name);
             mc.setScreen(null);
         }
+    }
+
+    /**
+     * Called for every command the client sends. Tracks {@code /home <name>}
+     * teleports (typed, macro'd, or triggered by the GUI) exactly once, so
+     * stats and history reflect real usage regardless of how the teleport was
+     * initiated.
+     */
+    public void onCommandSent(String command) {
+        if (command == null) return;
+        Matcher m = HOME_CMD.matcher(command.trim());
+        if (!m.find()) return;
+        String name = m.group(1);
+        // Use the canonical casing from the known homes list when available.
+        for (String h : homes) {
+            if (h.equalsIgnoreCase(name)) { name = h; break; }
+        }
+        ModConfig cfg = ModConfig.getInstance();
+        cfg.incrementUseCount(name);
+        cfg.addToHistory(name);
+        HomeGuiClient.scheduleCoordCapture(name);
     }
 
     public void onChatMessage(String message) {

--- a/src/main/java/com/maxlananas/homegui/config/LangManager.java
+++ b/src/main/java/com/maxlananas/homegui/config/LangManager.java
@@ -16,7 +16,8 @@ public class LangManager {
         "hint.search", "hint.create_home",
         "settings.language", "settings.sort", "settings.view", "settings.compact",
         "sort.default", "sort.alphabetical", "sort.most_used", "sort.recent", "sort.favorites_first",
-        "view.list", "view.grid"
+        "view.list", "view.grid",
+        "settings.transparent"
     };
 
     private static final Map<String, String[]> LANGS = new HashMap<>();
@@ -33,7 +34,8 @@ public class LangManager {
             "Search…","Use /sethome <name>",
             "Language","Sort","View","Compact",
             "Default","Alphabetical","Most used","Recent","Favorites first",
-            "List","Grid"
+            "List","Grid",
+            "Transparent"
         ));
         LANGS.put("fr", lang(
             "MES HOMES","STATISTIQUES","HISTORIQUE RÉCENT",
@@ -44,7 +46,8 @@ public class LangManager {
             "Rechercher…","Tapez /sethome <nom>",
             "Langue","Tri","Vue","Compact",
             "Défaut","Alphabétique","Plus utilisés","Récents","Favoris d'abord",
-            "Liste","Grille"
+            "Liste","Grille",
+            "Transparent"
         ));
         LANGS.put("es", lang(
             "MIS HOMES","ESTADÍSTICAS","HISTORIAL RECIENTE",
@@ -239,14 +242,12 @@ public class LangManager {
     public String get(String key) {
         String[] translations = LANGS.get(currentCode);
         if (translations == null) translations = LANGS.get("en");
-        for (int i = 0; i < KEYS.length; i++) {
-            if (KEYS[i].equals(key)) {
-                return (i < translations.length) ? translations[i] : key;
-            }
-        }
         String[] en = LANGS.get("en");
         for (int i = 0; i < KEYS.length; i++) {
-            if (KEYS[i].equals(key)) return (i < en.length) ? en[i] : key;
+            if (KEYS[i].equals(key)) {
+                if (i < translations.length) return translations[i];
+                return (i < en.length) ? en[i] : key;   // fall back to English, not the raw key
+            }
         }
         return key;
     }

--- a/src/main/java/com/maxlananas/homegui/config/ModConfig.java
+++ b/src/main/java/com/maxlananas/homegui/config/ModConfig.java
@@ -23,6 +23,7 @@ public class ModConfig {
 
     private int     themeIndex     = 0;
     private boolean compactMode    = false;
+    private boolean transparentMenu = false;
     private String  language       = "en";
     private String  sortMode       = "DEFAULT";
     private String  viewMode       = "list";
@@ -46,6 +47,8 @@ public class ModConfig {
     public void    setThemeIndex(int i)       { themeIndex = i; save(); }
     public boolean isCompactMode()            { return compactMode; }
     public void    setCompactMode(boolean c)  { compactMode = c; save(); }
+    public boolean isTransparentMenu()            { return transparentMenu; }
+    public void    setTransparentMenu(boolean t)  { transparentMenu = t; save(); }
     public String  getSortMode()              { return sortMode; }
     public void    setSortMode(String s)      { sortMode = s; save(); }
     public String  getViewMode()              { return viewMode; }
@@ -192,6 +195,7 @@ public class ModConfig {
             JsonObject json = new JsonObject();
             json.addProperty("themeIndex",     themeIndex);
             json.addProperty("compactMode",    compactMode);
+            json.addProperty("transparentMenu", transparentMenu);
             json.addProperty("language",       language);
             json.addProperty("sortMode",       sortMode);
             json.addProperty("viewMode",       viewMode);
@@ -237,6 +241,7 @@ public class ModConfig {
             JsonObject json = JsonParser.parseString(Files.readString(path)).getAsJsonObject();
             if (json.has("themeIndex"))     themeIndex     = json.get("themeIndex").getAsInt();
             if (json.has("compactMode"))    compactMode    = json.get("compactMode").getAsBoolean();
+            if (json.has("transparentMenu")) transparentMenu = json.get("transparentMenu").getAsBoolean();
             if (json.has("language"))       language       = json.get("language").getAsString();
             if (json.has("sortMode"))       sortMode       = json.get("sortMode").getAsString();
             if (json.has("viewMode"))       viewMode       = json.get("viewMode").getAsString();
@@ -280,7 +285,7 @@ public class ModConfig {
     }
 
     private void resetDefaults() {
-        themeIndex = 0; compactMode = false; language = "en";
+        themeIndex = 0; compactMode = false; transparentMenu = false; language = "en";
         sortMode = "DEFAULT"; viewMode = "list"; totalTeleports = 0;
         favorites.clear(); useCounts.clear(); homeCoords.clear(); history.clear();
         try { Files.deleteIfExists(getConfigPath()); } catch (IOException ignored) {}

--- a/src/main/java/com/maxlananas/homegui/config/SortMode.java
+++ b/src/main/java/com/maxlananas/homegui/config/SortMode.java
@@ -23,18 +23,13 @@ public enum SortMode {
         return DEFAULT;
     }
 
-    public List<String> apply(List<String> homes) {
-        return switch (this) {
-            case ALPHABETICAL -> {
-                var sorted = new java.util.ArrayList<>(homes);
-                sorted.sort(String::compareToIgnoreCase);
-                yield sorted;
-            }
+    /** Sorts {@code homes} in place according to this mode. */
+    public void apply(List<String> homes) {
+        switch (this) {
+            case ALPHABETICAL -> homes.sort(String::compareToIgnoreCase);
             case MOST_USED -> {
                 var cfg = ModConfig.getInstance();
-                var sorted = new java.util.ArrayList<>(homes);
-                sorted.sort((a, b) -> Integer.compare(cfg.getUseCount(b), cfg.getUseCount(a)));
-                yield sorted;
+                homes.sort((a, b) -> Integer.compare(cfg.getUseCount(b), cfg.getUseCount(a)));
             }
             case RECENT -> {
                 var cfg = ModConfig.getInstance();
@@ -43,20 +38,19 @@ public enum SortMode {
                 var sorted = new java.util.ArrayList<String>();
                 for (var n : recentNames) homes.stream().filter(h -> h.equalsIgnoreCase(n)).forEach(sorted::add);
                 homes.stream().filter(h -> !sorted.contains(h)).forEach(sorted::add);
-                yield sorted;
+                homes.clear();
+                homes.addAll(sorted);
             }
             case FAVORITES_FIRST -> {
                 var cfg = ModConfig.getInstance();
-                var sorted = new java.util.ArrayList<>(homes);
-                sorted.sort((a, b) -> {
+                homes.sort((a, b) -> {
                     int fa = cfg.isFavorite(a) ? 0 : 1;
                     int fb = cfg.isFavorite(b) ? 0 : 1;
                     if (fa != fb) return fa - fb;
                     return a.compareToIgnoreCase(b);
                 });
-                yield sorted;
             }
-            default -> homes;
-        };
+            default -> { }
+        }
     }
 }

--- a/src/main/java/com/maxlananas/homegui/mixin/SendCommandMixin.java
+++ b/src/main/java/com/maxlananas/homegui/mixin/SendCommandMixin.java
@@ -1,0 +1,23 @@
+package com.maxlananas.homegui.mixin;
+
+import com.maxlananas.homegui.HomesManager;
+import net.minecraft.client.multiplayer.ClientPacketListener;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+/**
+ * Tracks every command the client sends so that manually typed (or macro'd)
+ * {@code /home <name>} teleports are counted just like GUI teleports. Because
+ * the GUI also teleports through {@code sendCommand}, all tracking is funneled
+ * through this single choke point to avoid double counting.
+ */
+@Mixin(ClientPacketListener.class)
+public class SendCommandMixin {
+
+    @Inject(method = "sendCommand(Ljava/lang/String;)V", at = @At("HEAD"))
+    private void homegui$onSendCommand(String command, CallbackInfo ci) {
+        HomesManager.getInstance().onCommandSent(command);
+    }
+}

--- a/src/main/java/com/maxlananas/homegui/screen/HistoryScreen.java
+++ b/src/main/java/com/maxlananas/homegui/screen/HistoryScreen.java
@@ -95,7 +95,7 @@ public class HistoryScreen extends Screen {
         LangManager L = LangManager.getInstance();
         Font f = font;
 
-        g.fill(0, 0, width, height, Theme.BG);
+        g.fill(0, 0, width, height, Theme.backdrop());
 
         int panelY = 20;
         int panelH = height - 50;

--- a/src/main/java/com/maxlananas/homegui/screen/HomesScreen.java
+++ b/src/main/java/com/maxlananas/homegui/screen/HomesScreen.java
@@ -1,6 +1,5 @@
 package com.maxlananas.homegui.screen;
 
-import com.maxlananas.homegui.HomeGuiClient;
 import com.maxlananas.homegui.HomesManager;
 import com.maxlananas.homegui.config.LangManager;
 import com.maxlananas.homegui.config.ModConfig;
@@ -175,12 +174,7 @@ public class HomesScreen extends Screen {
             String label = (isFav ? "★ " : "") + home + (uses > 0 ? "  ×" + uses : "");
 
             addRenderableWidget(new StyledButton(listX, rowY, mainBtnW, ROW_H, label,
-                    () -> {
-                        ModConfig.getInstance().incrementUseCount(home);
-                        ModConfig.getInstance().addToHistory(home);
-                        HomeGuiClient.scheduleCoordCapture(home);
-                        HomesManager.getInstance().teleportToHome(home);
-                    }));
+                    () -> HomesManager.getInstance().teleportToHome(home)));
 
             addRenderableWidget(new StyledButton(listX + mainBtnW + 4, rowY, 22, ROW_H,
                     isFav ? "★" : "☆",
@@ -208,12 +202,7 @@ public class HomesScreen extends Screen {
             int cy = listAreaTop + row * (GRID_CARD_H + GRID_GAP);
 
             addRenderableWidget(new StyledButton(cx, cy, GRID_CARD_W, GRID_CARD_H, home,
-                    () -> {
-                        ModConfig.getInstance().incrementUseCount(home);
-                        ModConfig.getInstance().addToHistory(home);
-                        HomeGuiClient.scheduleCoordCapture(home);
-                        HomesManager.getInstance().teleportToHome(home);
-                    }));
+                    () -> HomesManager.getInstance().teleportToHome(home)));
         }
     }
 
@@ -222,7 +211,7 @@ public class HomesScreen extends Screen {
         LangManager L = LangManager.getInstance();
         Font f = font;
 
-        g.fill(0, 0, width, height, Theme.BG);
+        g.fill(0, 0, width, height, Theme.backdrop());
         int panelY = 20;
         int panelH = height - 50;
 
@@ -268,8 +257,8 @@ public class HomesScreen extends Screen {
             int thumbH = Math.max(20, sbH * visibleRows / filtered.size());
             int maxScroll = Math.max(1, filtered.size() - visibleRows);
             int thumbY = listAreaTop + (sbH - thumbH) * scrollOffset / maxScroll;
-            g.fill(sbX, listAreaTop, sbX + 4, listAreaBottom, Theme.CARD);
-            g.fill(sbX, thumbY, sbX + 4, thumbY + thumbH, Theme.ACCENT_DIM);
+            g.fill(sbX, listAreaTop, sbX + 4, listAreaBottom, Theme.bg(Theme.CARD));
+            g.fill(sbX, thumbY, sbX + 4, thumbY + thumbH, Theme.bg(Theme.ACCENT_DIM));
             Theme.fillBorder(g, sbX, thumbY, 4, thumbH, Theme.ACCENT);
         }
     }
@@ -285,7 +274,7 @@ public class HomesScreen extends Screen {
             int rowY = listAreaTop + (i - scrollOffset) * ROW_STEP;
             boolean isFav = ModConfig.getInstance().isFavorite(home);
             if (isFav) {
-                g.fill(listX, rowY, listX + 3, rowY + ROW_H, Theme.GOLD);
+                g.fill(listX, rowY, listX + 3, rowY + ROW_H, Theme.bg(Theme.GOLD));
             }
         }
     }
@@ -307,7 +296,7 @@ public class HomesScreen extends Screen {
             boolean isFav = cfg.isFavorite(home);
             int uses = cfg.getUseCount(home);
 
-            if (isFav) g.fill(cx, cy, cx + GRID_CARD_W, cy + 2, Theme.GOLD);
+            if (isFav) g.fill(cx, cy, cx + GRID_CARD_W, cy + 2, Theme.bg(Theme.GOLD));
 
             String displayName = Theme.truncate(f, home, GRID_CARD_W - 8);
             g.drawCenteredString(f, Component.literal(displayName),

--- a/src/main/java/com/maxlananas/homegui/screen/HomesScreen.java
+++ b/src/main/java/com/maxlananas/homegui/screen/HomesScreen.java
@@ -1,5 +1,6 @@
 package com.maxlananas.homegui.screen;
 
+import com.maxlananas.homegui.HomeGuiClient;
 import com.maxlananas.homegui.HomesManager;
 import com.maxlananas.homegui.config.LangManager;
 import com.maxlananas.homegui.config.ModConfig;
@@ -10,6 +11,7 @@ import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.EditBox;
 import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.input.KeyEvent;
 import net.minecraft.network.chat.Component;
 
 import java.util.ArrayList;
@@ -315,6 +317,17 @@ public class HomesScreen extends Screen {
                         cx + GRID_CARD_W / 2, cy + 42, Theme.FAINT);
             }
         }
+    }
+
+    @Override
+    public boolean keyPressed(KeyEvent event) {
+        // Pressing the open-GUI keybind again toggles the menu closed, unless the
+        // search box is focused (so the key can still be typed into a home name).
+        if ((searchBox == null || !searchBox.isFocused()) && HomeGuiClient.matchesOpenKey(event)) {
+            onClose();
+            return true;
+        }
+        return super.keyPressed(event);
     }
 
     @Override

--- a/src/main/java/com/maxlananas/homegui/screen/HomesScreen.java
+++ b/src/main/java/com/maxlananas/homegui/screen/HomesScreen.java
@@ -20,6 +20,8 @@ public class HomesScreen extends Screen {
 
     private static final int PANEL_W  = 320;
     private static final int PAD      = 16;
+    private static final int SEARCH_Y  = 60;
+    private static final int TOOLBAR_Y = SEARCH_Y + 24;
     private static final int ROW_H    = 22;
     private static final int ROW_GAP  = 3;
     private static final int ROW_STEP = ROW_H + ROW_GAP;
@@ -79,7 +81,7 @@ public class HomesScreen extends Screen {
 
         panelX = width / 2 - PANEL_W / 2;
         int searchW = PANEL_W - PAD * 2 - 26;
-        int searchY = 50;
+        int searchY = SEARCH_Y;
 
         searchBox = new EditBox(font, panelX + PAD, searchY, searchW, 16, Component.literal("Search"));
         searchBox.setValue(savedSearch);
@@ -228,12 +230,12 @@ public class HomesScreen extends Screen {
         Theme.drawTextCentered(g, f, "✦ " + L.get("title.homes") + " ✦",
                 width / 2, panelY + 10, Theme.ACCENT);
         Theme.drawTextCentered(g, f, "§8" + allHomes.size() + " " + L.get("stats.total_homes"),
-                width / 2, panelY + 24, Theme.DIM);
-        Theme.drawSeparator(g, panelX + PAD, 46, PANEL_W - PAD * 2);
+                width / 2, panelY + 22, Theme.DIM);
+        Theme.drawSeparator(g, panelX + PAD, SEARCH_Y - 7, PANEL_W - PAD * 2);
 
         if (searchBox != null && searchBox.getValue().isEmpty() && !searchBox.isFocused()) {
             g.drawString(f, Component.literal("§7" + L.get("hint.search")),
-                    panelX + PAD + 4, 54, Theme.FAINT);
+                    panelX + PAD + 4, SEARCH_Y + 4, Theme.FAINT);
         }
 
         if (filtered.isEmpty()) {
@@ -249,7 +251,7 @@ public class HomesScreen extends Screen {
 
         super.render(g, mouseX, mouseY, delta);
 
-        int toolbarY = 74;
+        int toolbarY = TOOLBAR_Y;
         Theme.drawSeparator(g, panelX + PAD, toolbarY + 20, PANEL_W - PAD * 2);
         int bottomY = 20 + panelH - 24;
         Theme.drawSeparator(g, panelX + PAD, bottomY - 10, PANEL_W - PAD * 2);

--- a/src/main/java/com/maxlananas/homegui/screen/SettingsScreen.java
+++ b/src/main/java/com/maxlananas/homegui/screen/SettingsScreen.java
@@ -62,6 +62,11 @@ public class SettingsScreen extends Screen {
         addRenderableWidget(new StyledButton(panelX + pad, y, btnW, rowH,
                 L.get("settings.compact") + ": " + (cfg.isCompactMode() ? "ON" : "OFF"),
                 () -> { cfg.setCompactMode(!cfg.isCompactMode()); needsRebuild = true; }));
+        y += rowH + gap;
+
+        addRenderableWidget(new StyledButton(panelX + pad, y, btnW, rowH,
+                L.get("settings.transparent") + ": " + (cfg.isTransparentMenu() ? "ON" : "OFF"),
+                () -> { cfg.setTransparentMenu(!cfg.isTransparentMenu()); needsRebuild = true; }));
         y += rowH + gap + 8;
 
         addRenderableWidget(new StyledButton(panelX + pad, y, btnW / 2 - 4, rowH,
@@ -82,7 +87,7 @@ public class SettingsScreen extends Screen {
         LangManager L = LangManager.getInstance();
         Font f = font;
 
-        g.fill(0, 0, width, height, Theme.BG);
+        g.fill(0, 0, width, height, Theme.backdrop());
 
         int panelX = width / 2 - PANEL_W / 2;
         int panelY = 20;

--- a/src/main/java/com/maxlananas/homegui/screen/StatsScreen.java
+++ b/src/main/java/com/maxlananas/homegui/screen/StatsScreen.java
@@ -44,7 +44,7 @@ public class StatsScreen extends Screen {
         ModConfig cfg = ModConfig.getInstance();
         List<String> homes = HomesManager.getInstance().getHomes();
 
-        g.fill(0, 0, width, height, Theme.BG);
+        g.fill(0, 0, width, height, Theme.backdrop());
 
         int panelX = width / 2 - PANEL_W / 2;
         int panelY = 15;

--- a/src/main/java/com/maxlananas/homegui/widget/StyledButton.java
+++ b/src/main/java/com/maxlananas/homegui/widget/StyledButton.java
@@ -44,11 +44,11 @@ public class StyledButton extends AbstractWidget {
         boolean hov = isHovered();
         int bx = getX(), by = getY(), bw = getWidth(), bh = getHeight();
 
-        g.fill(bx, by, bx + bw, by + bh, hov ? bgHover : bgNormal);
-        g.fill(bx, by, bx + bw, by + 1, hov ? borderAccent : Theme.BORDER);
-        g.fill(bx, by + bh - 1, bx + bw, by + bh, Theme.BORDER);
-        g.fill(bx, by, bx + 1, by + bh, Theme.BORDER);
-        g.fill(bx + bw - 1, by, bx + bw, by + bh, Theme.BORDER);
+        g.fill(bx, by, bx + bw, by + bh, Theme.bg(hov ? bgHover : bgNormal));
+        g.fill(bx, by, bx + bw, by + 1, Theme.bg(hov ? borderAccent : Theme.BORDER));
+        g.fill(bx, by + bh - 1, bx + bw, by + bh, Theme.bg(Theme.BORDER));
+        g.fill(bx, by, bx + 1, by + bh, Theme.bg(Theme.BORDER));
+        g.fill(bx + bw - 1, by, bx + bw, by + bh, Theme.bg(Theme.BORDER));
 
         Font font = Minecraft.getInstance().font;
         String raw = getMessage().getString();

--- a/src/main/java/com/maxlananas/homegui/widget/StyledButton.java
+++ b/src/main/java/com/maxlananas/homegui/widget/StyledButton.java
@@ -5,6 +5,7 @@ import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.AbstractWidget;
 import net.minecraft.client.gui.narration.NarrationElementOutput;
+import net.minecraft.client.input.MouseButtonEvent;
 import net.minecraft.network.chat.Component;
 
 public class StyledButton extends AbstractWidget {
@@ -34,7 +35,7 @@ public class StyledButton extends AbstractWidget {
     }
 
     @Override
-    public void onClick(double mouseX, double mouseY) {
+    public void onClick(MouseButtonEvent mouseButtonEvent, boolean doubled) {
         onPress.run();
     }
 

--- a/src/main/java/com/maxlananas/homegui/widget/StyledButton.java
+++ b/src/main/java/com/maxlananas/homegui/widget/StyledButton.java
@@ -3,11 +3,13 @@ package com.maxlananas.homegui.widget;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.GuiGraphics;
-import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.components.AbstractWidget;
+import net.minecraft.client.gui.narration.NarrationElementOutput;
 import net.minecraft.network.chat.Component;
 
-public class StyledButton extends Button {
+public class StyledButton extends AbstractWidget {
 
+    private final Runnable onPress;
     private final int bgNormal;
     private final int bgHover;
     private final int borderAccent;
@@ -17,9 +19,8 @@ public class StyledButton extends Button {
     public StyledButton(int x, int y, int w, int h, String label, Runnable onPress,
                         int bgNormal, int bgHover,
                         int borderAccent, int textNormal, int textHover) {
-        super(x, y, w, h, Component.literal(label),
-              b -> onPress.run(),
-              btn -> btn.get());
+        super(x, y, w, h, Component.literal(label));
+        this.onPress = onPress;
         this.bgNormal = bgNormal;
         this.bgHover = bgHover;
         this.borderAccent = borderAccent;
@@ -30,6 +31,11 @@ public class StyledButton extends Button {
     public StyledButton(int x, int y, int w, int h, String label, Runnable onPress) {
         this(x, y, w, h, label, onPress,
              Theme.BTN, Theme.BTN_HOV, Theme.BORDER, Theme.TEXT, 0xFFFFFFFF);
+    }
+
+    @Override
+    public void onClick(double mouseX, double mouseY) {
+        onPress.run();
     }
 
     @Override
@@ -49,5 +55,10 @@ public class StyledButton extends Button {
         int color = hov ? textHover : textNormal;
         g.drawCenteredString(font, Component.literal(label),
                 bx + bw / 2, by + (bh - 8) / 2, color);
+    }
+
+    @Override
+    protected void updateWidgetNarration(NarrationElementOutput narration) {
+        defaultButtonNarrationText(narration);
     }
 }

--- a/src/main/java/com/maxlananas/homegui/widget/Theme.java
+++ b/src/main/java/com/maxlananas/homegui/widget/Theme.java
@@ -1,5 +1,6 @@
 package com.maxlananas.homegui.widget;
 
+import com.maxlananas.homegui.config.ModConfig;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.GuiGraphics;
@@ -7,6 +8,10 @@ import net.minecraft.network.chat.Component;
 
 public final class Theme {
     private Theme() {}
+
+    // Alpha multipliers applied to structural fills when transparent menu mode is on.
+    private static final float PANEL_ALPHA    = 0.62f;
+    private static final float BACKDROP_ALPHA = 0.20f;
 
     public static final int BG          = 0xFF080816;
     public static final int PANEL       = 0xFF0E0E24;
@@ -31,7 +36,29 @@ public final class Theme {
     public static final int BTN         = 0xFF161638;
     public static final int BTN_HOV     = 0xFF222255;
 
+    private static boolean transparent() {
+        return ModConfig.getInstance().isTransparentMenu();
+    }
+
+    /** Multiplies the alpha channel of an ARGB color by {@code mult} (clamped to 0-255). */
+    public static int withAlpha(int argb, float mult) {
+        int a = Math.round(((argb >>> 24) & 0xFF) * mult);
+        a = Math.max(0, Math.min(255, a));
+        return (a << 24) | (argb & 0x00FFFFFF);
+    }
+
+    /** Structural fill color (panels, cards, buttons, borders), dimmed in transparent mode. */
+    public static int bg(int argb) {
+        return transparent() ? withAlpha(argb, PANEL_ALPHA) : argb;
+    }
+
+    /** Full-screen backdrop color, strongly dimmed in transparent mode so the world shows through. */
+    public static int backdrop() {
+        return transparent() ? withAlpha(BG, BACKDROP_ALPHA) : BG;
+    }
+
     public static void fillBorder(GuiGraphics g, int x, int y, int w, int h, int c) {
+        c = bg(c);
         g.fill(x, y, x + w, y + 1, c);
         g.fill(x, y + h - 1, x + w, y + h, c);
         g.fill(x, y, x + 1, y + h, c);
@@ -39,20 +66,20 @@ public final class Theme {
     }
 
     public static void drawPanel(GuiGraphics g, int x, int y, int w, int h) {
-        g.fill(x - 2, y - 2, x + w + 2, y + h + 2, ACCENT_GLOW);
-        g.fill(x, y, x + w, y + h, PANEL);
+        g.fill(x - 2, y - 2, x + w + 2, y + h + 2, bg(ACCENT_GLOW));
+        g.fill(x, y, x + w, y + h, bg(PANEL));
         fillBorder(g, x, y, w, h, BORDER);
-        g.fill(x + 1, y, x + w - 1, y + 2, ACCENT);
+        g.fill(x + 1, y, x + w - 1, y + 2, bg(ACCENT));
     }
 
     public static void drawCard(GuiGraphics g, int x, int y, int w, int h, int accentColor) {
-        g.fill(x, y, x + w, y + h, CARD);
-        g.fill(x, y, x + w, y + 2, accentColor);
+        g.fill(x, y, x + w, y + h, bg(CARD));
+        g.fill(x, y, x + w, y + 2, bg(accentColor));
         fillBorder(g, x, y, w, h, BORDER);
     }
 
     public static void drawSeparator(GuiGraphics g, int x, int y, int w) {
-        g.fill(x, y, x + w, y + 1, BORDER);
+        g.fill(x, y, x + w, y + 1, bg(BORDER));
     }
 
     public static void drawTextCentered(GuiGraphics g, Font font, String text, int cx, int y, int color) {

--- a/src/main/resources/homegui.mixins.json
+++ b/src/main/resources/homegui.mixins.json
@@ -4,7 +4,8 @@
   "package": "com.maxlananas.homegui.mixin",
   "compatibilityLevel": "JAVA_21",
   "client": [
-    "ChatHudMixin"
+    "ChatHudMixin",
+    "SendCommandMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
## Summary
Fixes a hard crash on Minecraft 1.21.11 and adds a few quality-of-life features.

## Bug fixes
- **Fix crash when opening the GUI on 1.21.11** (`IncompatibleClassChangeError`):
  `renderWidget` became `final` in `AbstractButton`, so `StyledButton` now extends
  `AbstractWidget` and overrides the 1.21.10+ input signatures
  (`onClick(MouseButtonEvent, boolean)`, `keyPressed(KeyEvent)`).
- **Sorting had no effect**: `SortMode.apply()` returned a new list that the caller
  discarded — it now sorts in place.
- **Header layout**: the "N homes" counter no longer renders behind the search box
  (shared SEARCH_Y/TOOLBAR_Y constants instead of duplicated hardcoded offsets).

## Features
- **Track manually typed / macro'd `/home <name>` teleports** via a
  `ClientPacketListener.sendCommand` mixin, so stats, history and coords reflect
  real usage — not only GUI clicks. All counting is funneled through one place to
  avoid double-counting GUI teleports.
- **Transparent menu setting**: dims panels/buttons/backdrop while keeping text
  readable (no visual change when off).
- **Keybind toggle**: pressing the open key again closes the menu.

## Testing
Built via the repo's Build workflow and tested in-game on a Paper server (1.21.11):
crash gone, sorting works, manual `/home` teleports counted once, transparency and
toggle behave as expected.

## Note
`gradle.properties` targets 1.21.10; the fixes also cover the 1.21.11 runtime crash.